### PR TITLE
Migrate relayer dns to mooo.com, privatedns.org has gone down

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -40,9 +40,9 @@ export const rCELOMap: Record<ChainId, Record<string, number>> = {
 
 export const RELAYERS = {
   [ChainId.Mainnet]: [
-    "https://adamaris.privatedns.org",
-    "https://bellagio.privatedns.org",
-    "https://maralago.privatedns.org",
+    "https://adamaris.mooo.com",
+    "https://bellagio.mooo.com",
+    "https://maralago.mooo.com",
     "https://aarde.thkpool.com",
   ],
   [ChainId.Alfajores]: ["https://relayer-test.poof.cash"],


### PR DESCRIPTION
Privatedns.org has gone down, migrate the relayer dns host to mooo.com