### PR TITLE
update number util for foreign number displays

### DIFF
--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -13,7 +13,7 @@ export const humanFriendlyNumber = (v: number | string) => {
   const formatted = num.toLocaleString(undefined, {
     minimumFractionDigits: 20,
   });
-  const decimalIdx = formatted.indexOf(".");
+  const decimalIdx = formatted.indexOf(".") !== -1 ? formatted.indexOf(".") : formatted.indexOf(',')
   if (decimalIdx === -1) {
     return formatted;
   }


### PR DESCRIPTION
Right now the number util parses for the decimal and then cuts off the numbers after the decimal to display the number in a more friendly way. For users who have configured their browser to display with commas and decimals swapped in numbers, it ends up showing way too many decimals. This checks for commas if no decimals are present